### PR TITLE
Fix compiler error in which fprintf, stderr are not declared

### DIFF
--- a/src/LaserdockDeviceManager.h
+++ b/src/LaserdockDeviceManager.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <vector>
+#include <cstdio>
 
 #ifdef _WIN32
 #define LASERDOCKLIB_EXPORT __declspec(dllexport)


### PR DESCRIPTION
Problem: when compiling get_devices in LaserdockDeviceManager_desktop.cpp, one line fails to compile because fprintf and stderr are not declared in the scope. This can be fixed by including <cstdio> in LaserdockDeviceManager.h.